### PR TITLE
Merge pull request #36 from balazsorban44/patch-1

### DIFF
--- a/src/prompt.ts
+++ b/src/prompt.ts
@@ -135,7 +135,7 @@ export default async function prompt({
   const gitmoji = answers.gitmoji ? `${answers.gitmoji} ` : '';
 
   // Hard limit this line
-  let head = `${answers.type}${scope}: ${gitmoji}${answers.subject.trim()}`;
+  let head = `${answers.type}${scope}: ${gitmoji} ${answers.subject.trim()}`;
   head = head.slice(0, maxHeaderLength);
 
   // Wrap these lines


### PR DESCRIPTION
I recommend adding a space between the emoji and the text, as in some cases (like my own), emojis tend to overlap with their following character on the terminal.

(I also think it is a bit prettier to look at the commit log that way, but it may be a personal opinion)

```diff
- type(scope): 🔧some text
+ type(scope): 🔧 some text
```